### PR TITLE
feat(vite-plugin-component-insight): add insight exclude option

### DIFF
--- a/packages/vite-plugin-component-insight/README.md
+++ b/packages/vite-plugin-component-insight/README.md
@@ -61,11 +61,15 @@ componentInsight({
 interface VitePluginComponentInsightOptions {
   reportMarkdownPath?: string;
   logToConsole?: boolean;
+  exclude?: string[];
+  include?: string[];
 }
 ```
 
 - reportMarkdownPath: 自定义 Markdown 报告输出路径，不传则不生成 Markdown
 - logToConsole: 是否输出控制台日志，默认开启
+- exclude: 指定过滤的文件，默认过滤  node_modules 和 uni_modules
+- include: 指定包含的文件, 默认为空
 
 ## 许可证
 

--- a/packages/vite-plugin-component-insight/src/index.ts
+++ b/packages/vite-plugin-component-insight/src/index.ts
@@ -44,11 +44,13 @@ interface ComponentInsightReport {
 export interface VitePluginComponentInsightOptions {
   reportMarkdownPath?: string;
   logToConsole?: boolean;
+  exclude?: string[];
 }
 
 const DEFAULT_OPTIONS: Required<VitePluginComponentInsightOptions> = {
   reportMarkdownPath: '',
   logToConsole: true,
+  exclude: ['node-modules', 'uni_modules'],
 };
 
 function normalizeSlashes(value: string) {
@@ -294,6 +296,9 @@ export default function vitePluginComponentInsight(options: VitePluginComponentI
         for (const [componentName, componentRef] of Object.entries(record.usingComponents)) {
           const childJsonRelativePath = resolveUsingComponentPath(record.jsonRelativePath, componentRef, outputDir);
           if (!childJsonRelativePath) {
+            continue;
+          }
+          if (resolvedOptions.exclude && resolvedOptions.exclude.some((val) => componentRef.indexOf(val) > -1)) {
             continue;
           }
           const childRecord = outputJsonMap.get(childJsonRelativePath);

--- a/packages/vite-plugin-component-insight/src/index.ts
+++ b/packages/vite-plugin-component-insight/src/index.ts
@@ -4,6 +4,7 @@ import { parseJson, parseSubpackagesRootOnce } from '@dcloudio/uni-cli-shared';
 import { isMiniProgram } from '@uni_toolkit/shared';
 import pc from 'picocolors';
 import type { PluginOption } from 'vite';
+import { createFilter } from 'vite';
 
 interface PageEntry {
   path: string;
@@ -45,12 +46,14 @@ export interface VitePluginComponentInsightOptions {
   reportMarkdownPath?: string;
   logToConsole?: boolean;
   exclude?: string[];
+  include?: string[];
 }
 
 const DEFAULT_OPTIONS: Required<VitePluginComponentInsightOptions> = {
   reportMarkdownPath: '',
   logToConsole: true,
-  exclude: ['node-modules', 'uni_modules'],
+  exclude: ['**/node-modules/**', '**/node_modules/**', '**/uni_modules/**'],
+  include: [],
 };
 
 function normalizeSlashes(value: string) {
@@ -266,6 +269,8 @@ export default function vitePluginComponentInsight(options: VitePluginComponentI
       const jsonFiles = listJsonFiles(outputDir);
       const outputJsonMap = new Map<string, OutputJsonRecord>();
 
+      const flutterPath = createFilter(resolvedOptions.include, resolvedOptions.exclude);
+
       for (const jsonFile of jsonFiles) {
         const jsonRelativePath = normalizeSlashes(path.relative(outputDir, jsonFile));
         const jsonContent = readJsonFile<{
@@ -298,9 +303,11 @@ export default function vitePluginComponentInsight(options: VitePluginComponentI
           if (!childJsonRelativePath) {
             continue;
           }
-          if (resolvedOptions.exclude && resolvedOptions.exclude.some((val) => componentRef.indexOf(val) > -1)) {
+
+          if (flutterPath(componentRef)) {
             continue;
           }
+
           const childRecord = outputJsonMap.get(childJsonRelativePath);
           if (!childRecord?.isComponent) {
             continue;


### PR DESCRIPTION
feat(vite-plugin-component-insight): add insight exclude option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable include/exclude options to control which components are analyzed; `exclude` defaults to skipping node_modules and uni_modules, `include` defaults to empty.
* **Documentation**
  * Updated configuration docs to describe the new include and exclude options and their default behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->